### PR TITLE
Add additional keyboard navigation from Bash

### DIFF
--- a/sh/input.c
+++ b/sh/input.c
@@ -520,7 +520,8 @@ YoriShEnsureStringHasEnoughCharacters(
 {
     DWORD NewLength;
 
-    if (CharactersNeeded > String->LengthAllocated) {
+    if (CharactersNeeded + 1 > String->LengthAllocated) {
+
 
         //
         // Ensure the buffer is large enough for the requested length, but at
@@ -529,8 +530,8 @@ YoriShEnsureStringHasEnoughCharacters(
         //
 
         NewLength = String->LengthAllocated * 2;
-        if (NewLength < CharactersNeeded) {
-            NewLength = CharactersNeeded;
+        if (NewLength < CharactersNeeded + 1) {
+            NewLength = CharactersNeeded + 1;
         }
 
         if (!YoriLibReallocateString(String, NewLength)) {
@@ -2181,6 +2182,7 @@ YoriShProcessKeyDown(
                 memcpy(YoriShGlobal.YankBuffer.StartOfString, Buffer->String.StartOfString + Buffer->CurrentOffset, TailLength * sizeof(TCHAR));
                 YoriShGlobal.YankBuffer.LengthInChars = TailLength;
                 Buffer->String.LengthInChars = Buffer->CurrentOffset;
+                YoriLibFreeStringContents(&Buffer->SuggestionString);
                 Buffer->SuggestionDirty = TRUE;
             }
 

--- a/sh/input.c
+++ b/sh/input.c
@@ -2120,6 +2120,10 @@ YoriShProcessKeyDown(
                CtrlMask == (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED)) {
         if (KeyCode == 'A') {
             Buffer->CurrentOffset = 0;
+        } else if (KeyCode == 'B') {
+            if (Buffer->CurrentOffset > 0) {
+                Buffer->CurrentOffset--;
+            }
         } else if (KeyCode == 'C') {
             if (!YoriLibCopySelectionIfPresent(&Buffer->Selection)) {
                 YoriShClearInputSelections(Buffer);
@@ -2140,6 +2144,10 @@ YoriShProcessKeyDown(
             }
         } else if (KeyCode == 'E') {
             Buffer->CurrentOffset = Buffer->String.LengthInChars;
+        } else if (KeyCode == 'F') {
+            if (Buffer->CurrentOffset < Buffer->String.LengthInChars) {
+                Buffer->CurrentOffset++;
+            }
         } else if (KeyCode == 'K') {
 
             //

--- a/sh/main.c
+++ b/sh/main.c
@@ -747,6 +747,7 @@ ymain (
     YoriLibFreeStringContents(&YoriShGlobal.PromptVariable);
     YoriLibFreeStringContents(&YoriShGlobal.TitleVariable);
     YoriLibFreeStringContents(&YoriShGlobal.NextCommand);
+    YoriLibFreeStringContents(&YoriShGlobal.YankBuffer);
 
     return YoriShGlobal.ExitProcessExitCode;
 }

--- a/sh/yoristru.h
+++ b/sh/yoristru.h
@@ -997,6 +997,12 @@ typedef struct _YORI_SH_GLOBALS {
      */
     WORD MouseoverColor;
 
+    /**
+     The current yanked string, similar to the system clipboard but used only
+     for the kill and yank commands (Ctrl+K and Ctrl+Y).
+     */
+    YORI_STRING YankBuffer;
+
 } YORI_SH_GLOBALS, *PYORI_SH_GLOBALS;
 
 extern YORI_SH_GLOBALS YoriShGlobal;


### PR DESCRIPTION
This set of commits adds additional input keyboard navigation commands:

* Ctrl-B, Ctrl-F: aliases for Left, Right
* Ctrl-D: alias for DEL (when the input is non-empty, otherwise it's still `EXIT`)
* Ctrl-K: removes to the end of input
* Ctrl-Y: pastes string that was removed by most recent Ctrl-K
