### PR TITLE
Check timethis missing argument

### DIFF
--- a/timethis/timethis.c
+++ b/timethis/timethis.c
@@ -285,7 +285,7 @@ ENTRYPOINT(
     YORI_STRING CmdLine;
     DWORD ExitCode;
     BOOL ArgumentUnderstood;
-    DWORD StartArg = 1;
+    DWORD StartArg = 0;
     DWORD i;
     YORI_STRING Arg;
     YORI_STRING DisplayString;


### PR DESCRIPTION
Check for missing argument when running `timethis` reference in #54. Running `timethis` now without an argument prints "timethis: missing argument".