### PR TITLE
Add binary and octal bases to Yori

### DIFF
--- a/expr/expr.c
+++ b/expr/expr.c
@@ -39,6 +39,8 @@ CHAR strExprHelpText[] =
         "     <Number>[+|-|*|/|%|<|>|^]<Number>...\n"
         "\n"
         "   -h             Output result as hex rather than decimal\n"
+        "   -o             Output result as oct rather than decimal\n"
+        "   -b             Output result as bin rather than decimal\n"
         "   -int8          Output result as a signed 8 bit value\n"
         "   -int16         Output result as a signed 16 bit value\n"
         "   -int32         Output result as a signed 32 bit value\n"
@@ -75,8 +77,8 @@ typedef struct _EXPR_NUMBER {
 
 /**
  This routine attempts to convert a string to a number using all available
- parsing.  As of this writing, it understands 0x and 0n prefixes as well
- as negative numbers.
+ parsing.  As of this writing, it understands 0x and 0n and 0o and 0b prefixes
+ as well as negative numbers.
 
  @param String Pointer to the string to convert into integer form.
 
@@ -161,7 +163,7 @@ ENTRYPOINT(
     )
 {
     BOOL ArgumentUnderstood;
-    BOOL OutputHex = FALSE;
+    DWORD OutputBase = 10;
     BOOL OutputSeperator = FALSE;
     DWORD i;
     DWORD StartArg = 0;
@@ -188,7 +190,13 @@ ENTRYPOINT(
                 YoriLibDisplayMitLicense(_T("2017-2019"));
                 return EXIT_SUCCESS;
             } else if (YoriLibCompareStringWithLiteralInsensitive(&Arg, _T("h")) == 0) {
-                OutputHex = TRUE;
+                OutputBase = 16;
+                ArgumentUnderstood = TRUE;
+            } else if (YoriLibCompareStringWithLiteralInsensitive(&Arg, _T("o")) == 0) {
+                OutputBase = 8;
+                ArgumentUnderstood = TRUE;
+            } else if (YoriLibCompareStringWithLiteralInsensitive(&Arg, _T("b")) == 0) {
+                OutputBase = 2;
                 ArgumentUnderstood = TRUE;
             } else if (YoriLibCompareStringWithLiteralInsensitive(&Arg, _T("int8")) == 0) {
                 BitsInOutput = 7;
@@ -378,13 +386,7 @@ ENTRYPOINT(
 
     YoriLibFreeStringContents(&RemainingString);
 
-    if (OutputHex) {
-        ExprOutputNumber(Result, FALSE, 16);
-    } else if (OutputSeperator) {
-        ExprOutputNumber(Result, TRUE, 10);
-    } else {
-        ExprOutputNumber(Result, FALSE, 10);
-    }
+    ExprOutputNumber(Result, OutputSeperator, OutputBase);
 
     return EXIT_SUCCESS;
 }

--- a/lib/string.c
+++ b/lib/string.c
@@ -297,11 +297,11 @@ YoriLibDecimalStringToInt(
 
 /**
  This routine attempts to convert a string to a number using a specified
- number base (ie., decimal or hexadecimal.)  
+ number base (ie., decimal or hexadecimal or octal or binary.)
 
  @param String Pointer to the string to convert into integer form.
 
- @param Base The number base.  Must be 10 or 16.
+ @param Base The number base.  Must be 10 or 16 or 8 or 2.
 
  @param IgnoreSeperators If TRUE, continue to generate a number across comma
         delimiters.  If FALSE, terminate on a comma.
@@ -365,6 +365,18 @@ YoriLibStringToNumberSpecifyBase(
                 } else {
                     break;
                 }
+            } else if (Base == 8) {
+                if (String->StartOfString[Index] < '0' || String->StartOfString[Index] > '8') {
+                    break;
+                }
+                Result *= Base;
+                Result += String->StartOfString[Index] - '0';
+            } else if (Base == 2) {
+                if (String->StartOfString[Index] != '0' && String->StartOfString[Index] != '1') {
+                    break;
+                }
+                Result *= Base;
+                Result += String->StartOfString[Index] - '0';
             }
         }
     }
@@ -380,8 +392,8 @@ YoriLibStringToNumberSpecifyBase(
 
 /**
  This routine attempts to convert a string to a number using all available
- parsing.  As of this writing, it understands 0x and 0n prefixes as well
- as negative numbers.
+ parsing.  As of this writing, it understands 0x and 0n and 0o and 0x prefixes
+ as well as negative numbers.
 
  @param String Pointer to the string to convert into integer form.
 
@@ -425,6 +437,16 @@ YoriLibStringToNumber(
                    String->StartOfString[Index + 1] == 'n') {
             Base = 10;
             Index += 2;
+        } else if (String->StartOfString[Index] == '0' &&
+                   String->LengthInChars > Index + 1 &&
+                   String->StartOfString[Index + 1] == 'o') {
+            Base = 8;
+            Index += 2;
+        } else if (String->StartOfString[Index] == '0' &&
+                   String->LengthInChars > Index + 1 &&
+                   String->StartOfString[Index + 1] == 'b') {
+            Base = 2;
+            Index += 2;
         } else if (String->StartOfString[Index] == '-') {
             if (Negative) {
                 Negative = FALSE;
@@ -457,6 +479,18 @@ YoriLibStringToNumber(
                 } else {
                     break;
                 }
+            } else if (Base == 8) {
+                if (String->StartOfString[Index] < '0' || String->StartOfString[Index] > '8') {
+                    break;
+                }
+                Result *= Base;
+                Result += String->StartOfString[Index] - '0';
+            } else if (Base == 2) {
+                if (String->StartOfString[Index] != '0' && String->StartOfString[Index] != '1') {
+                    break;
+                }
+                Result *= Base;
+                Result += String->StartOfString[Index] - '0';
             }
         }
     }


### PR DESCRIPTION
In C, there are hexadecimal, decimal, octal and binary bases.
In Yori, there are only hexadecimal and decimal bases.
This change adds octal and binary bases to Yori.