### PR TITLE
Edit fixes

### DIFF
--- a/edit/edit.c
+++ b/edit/edit.c
@@ -400,6 +400,10 @@ EditSaveFile(
     if (FileName->StartOfString == NULL) {
         return FALSE;
     }
+    if (EditContext->Newline.StartOfString == NULL) {
+        YoriLibConstantString(&EditContext->Newline.StartOfString, _T("\r\n"));
+    }
+    
 
     ASSERT(YoriLibIsStringNullTerminated(FileName));
 

--- a/edit/options.c
+++ b/edit/options.c
@@ -173,7 +173,8 @@ EditOpts(
 
         if (YoriLibStringToNumber(&Caption, FALSE, &llTemp, &CharsConsumed) &&
             CharsConsumed > 0 &&
-            llTemp <= 64) {
+            llTemp <= 64 &&
+            llTemp >= 0) {
 
             DWORD dwTemp;
             dwTemp = (DWORD)llTemp;


### PR DESCRIPTION
This change contains some fixes for `EDIT`:
- when saving, set newline to `\r\n`, if newline is `NULL`
- do not allow to set a negative tab width (which causes crash)