### PR TITLE
Visual C++ 5 building fix and improvements to if

### DIFF
--- a/builtins/if.c
+++ b/builtins/if.c
@@ -37,7 +37,11 @@ CHAR strIfHelpText[] =
         "\n"
         "Execute a command to evaluate a condition.\n"
         "\n"
-        "IF [-license] <test cmd>; <true cmd>; <false cmd>\n";
+        "IF -license\n"
+        "IF <test cmd>; <true cmd>\n"
+        "IF <test cmd>; [<true cmd>]; <false cmd>\n"
+        "\n"
+        "<test cmd> should return an exit code of 0 for true or non-zero for false.\n";
 
 /**
  Display usage text to the user.
@@ -90,7 +94,10 @@ IfFindOffsetOfNextComponent(
             EscapeSubset.LengthInChars = String->LengthInChars - CharIndex - 2;
             EndOfEscape = YoriLibCntStringWithChars(&EscapeSubset, _T("0123456789;"));
             CharIndex += 2 + EndOfEscape;
-        } else if (String->StartOfString[CharIndex] == ';') {
+        } else if (String->LengthInChars > CharIndex + 2 &&
+                   String->StartOfString[CharIndex] == ';' &&
+                   String->StartOfString[CharIndex + 1] == ' ') {
+
             String->StartOfString[CharIndex] = '\0';
             *Offset = CharIndex;
             return TRUE;

--- a/hexdump/hexdump.c
+++ b/hexdump/hexdump.c
@@ -781,6 +781,7 @@ HexDumpBinaryParseLine(
 
     ReverseContext->BytesThisLine = 0;
 
+    StartChar = 0;
     Index = 0;
     Result = TRUE;
 


### PR DESCRIPTION
Compilation with Visual C++ 5.0 was throwing a warning about a `StartChar` variable in the code for `hexdump` possibly being used without being initialized, causing building to fail since `-WX` is among the compilation flags. The first commit fixes this.

Also, I have found the current command parsing in `if` to be problematic. Consider the following example:

`if strcmp 1==1; set TEST=%PATH%`

This will set TEST to only the first PATH entry, because `if` mistakes the semicolon separators in PATH as command separators. My second commit proposes changing the code to look for a semicolon followed by a space as a command separator; this is still in accordance with the syntax specified by the help text, but does avoid mis-parsing of semicolons in likely cases such as this. In the less likely event one needs '`; `' to be part of a command, they can still escape it. While I was at it, I also clarified the help text regarding `if`'s syntax/usage.

**Comment:** What is the reasoning for `if` using escaped arguments to parse the test command line, but not the true and false commands? This results in one having to double-escape characters in those commands for the escapes to work like they do elsewhere: a true or false command of `echo ^^%VAR^^%` is necessary for one to see the text `%VAR%` printed like one probably intends instead of the variable's value. Likewise, '`; `' has to be escaped as '`^^; `' to not be parsed as a command separator.