### PR TITLE
Allow to use the BUILTIN keyword in aliases

### DIFF
--- a/sh/complete.c
+++ b/sh/complete.c
@@ -2021,6 +2021,8 @@ YoriShPerformArgumentTabCompletion(
         //  aliases and path to an unambiguous thing to execute.
         //
 
+        YoriShExpandAlias(CmdContext);
+
         if (!YoriShResolveCommandToExecutable(&CurrentExecContext->CmdToExec, &ExecutableFound)) {
             YoriLibShFreeExecPlan(&ExecPlan);
             return;

--- a/sh/exec.c
+++ b/sh/exec.c
@@ -414,6 +414,8 @@ YoriShExecExecPlan(
             break;
         }
 
+        YoriShExpandAlias(&ExecContext->CmdToExec);
+
         if (YoriLibIsPathUrl(&ExecContext->CmdToExec.ArgV[0])) {
             YoriShGlobal.ErrorLevel = YoriShExecuteSingleProgram(ExecContext);
         } else if (ExecContext->CmdToExec.ArgC >= 2 &&

--- a/sh/parse.c
+++ b/sh/parse.c
@@ -53,8 +53,6 @@ YoriShResolveCommandToExecutable(
 
     YoriLibInitEmptyString(&FoundExecutable);
 
-    YoriShExpandAlias(CmdContext);
-
     if (!YoriLibExpandHomeDirectories(&CmdContext->ArgV[0], &ExpandedCmd)) {
         YoriLibCloneString(&ExpandedCmd, &CmdContext->ArgV[0]);
     }


### PR DESCRIPTION
Example to demonstrate the idea:
<img width="682" height="210" alt="image" src="https://github.com/user-attachments/assets/82f56573-4120-4eb1-8124-dd7004d9a5d1" />
