### PR TITLE
Handle tail -n with plus sign like GNU

### DIFF
--- a/lib/ylstrnum.c
+++ b/lib/ylstrnum.c
@@ -219,6 +219,8 @@ YoriLibStringToNumber(
                 Negative = TRUE;
             }
             Index++;
+        } else if (String->StartOfString[Index] == '+') {
+            Index++;
         } else {
             break;
         }


### PR DESCRIPTION
Handle tail -n with plus sign like GNU, i.e., limit output to the lines following from given line.